### PR TITLE
refactor: rename ValidateHeaders to ValidateHeader

### DIFF
--- a/validator/internal/centralconsumer/centralconsumer.go
+++ b/validator/internal/centralconsumer/centralconsumer.go
@@ -97,8 +97,8 @@ type Settings struct {
 	// NumInferrers defines the maximum amount of inflight destination topic inference jobs (validation and routing).
 	NumInferrers int
 
-	// ValidateHeaders defines if the messages' headers will be validated
-	ValidateHeaders bool
+	// ValidateHeader defines if the messages' headers will be validated
+	ValidateHeader bool
 
 	// DefaultHeaderSchemaId is default ID of the header schema
 	DefaultHeaderSchemaId string
@@ -143,7 +143,7 @@ func New(registry registry.SchemaRegistry, publisher broker.Publisher, validator
 	if settings.NumInferrers > 0 {
 		validatorsSem = make(chan struct{}, settings.NumInferrers)
 	}
-	if settings.ValidateHeaders {
+	if settings.ValidateHeader {
 		_, ok := validators["json"]
 		if !ok {
 			// if json validation is turned off, this version of json validator is used by default for validating message header
@@ -200,7 +200,7 @@ func New(registry registry.SchemaRegistry, publisher broker.Publisher, validator
 			Specification: schemaVersion.Specification,
 		},
 		encryptionKey:   encryptionKey,
-		validateHeaders: settings.ValidateHeaders,
+		validateHeaders: settings.ValidateHeader,
 		defaultHeaderSchema: config.DefaultHeaderSchema{
 			DefaultHeaderSchemaId:      settings.DefaultHeaderSchemaId,
 			DefaultHeaderSchemaVersion: settings.DefaultHeaderSchemaVersion,

--- a/validator/internal/config/centralconsumer.go
+++ b/validator/internal/config/centralconsumer.go
@@ -30,7 +30,7 @@ type CentralConsumer struct {
 	ShouldLog              CentralConsumerShouldLog  `toml:"should_log"`
 	NumSchemaCollectors    int                       `toml:"num_schema_collectors" default:"-1"`
 	NumInferrers           int                       `toml:"num_inferrers" default:"-1"`
-	ValidateHeaders        bool                      `toml:"validate_headers"`
+	ValidateHeader         bool                      `toml:"validate_header"`
 	DefaultHeaderSchema    DefaultHeaderSchema       `toml:"default_header_schema"`
 	MetricsLoggingInterval time.Duration             `toml:"metrics_logging_interval" default:"5s"`
 	RunOptions             RunOptions                `toml:"run_option"`

--- a/validator/internal/janitorctl/run.go
+++ b/validator/internal/janitorctl/run.go
@@ -86,7 +86,7 @@ func RunCentralConsumer(configFile string) {
 			centralconsumer.Settings{
 				NumSchemaCollectors:        cfg.NumSchemaCollectors,
 				NumInferrers:               cfg.NumInferrers,
-				ValidateHeaders:            cfg.ValidateHeaders,
+				ValidateHeader:             cfg.ValidateHeader,
 				DefaultHeaderSchemaId:      cfg.DefaultHeaderSchema.DefaultHeaderSchemaId,
 				DefaultHeaderSchemaVersion: cfg.DefaultHeaderSchema.DefaultHeaderSchemaVersion,
 			},


### PR DESCRIPTION
## Description
Changed the env variable that enables/disables header validation to have the same name as the header parameter that enables/disables header validation for only that message.

## Type of change
<!-- Check the type(s) of changes made in this PR -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (improving code structure without changing external behavior)
- [ ] Other (please explain):

## Checklist
<!-- Ensure all items are complete before submitting your pull request. -->

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My code is well documented
- [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)

## How Has This Been Tested?
Tested by confirming that the header validation is turned on/off by default.
